### PR TITLE
feat: add React quote generator

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,11 @@
   "dependencies": {
     "lucide-react": "^0.344.0",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "file-saver": "^2.0.5",
+    "html-docx-js": "^0.4.1",
+    "html2canvas": "^1.4.1",
+    "jspdf": "^2.5.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",


### PR DESCRIPTION
## Summary
- replace static redirect with interactive React quote generator
- manage dynamic products, totals, and export to PDF/Word
- add export library dependencies

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a57d7a90ec8329a81f5298fc7129d1